### PR TITLE
add uint8_t casts

### DIFF
--- a/src/SparkFun_SHTC3.cpp
+++ b/src/SparkFun_SHTC3.cpp
@@ -181,7 +181,7 @@ SHTC3_Status_TypeDef SHTC3::checkID()
 		return exitOp(retval, __FILE__, __LINE__);
 	}
 
-	numBytesRx = _wire->requestFrom(SHTC3_ADDR_7BIT, numBytesRequest);
+	numBytesRx = _wire->requestFrom((uint8_t)SHTC3_ADDR_7BIT, numBytesRequest);
 	if (numBytesRx != numBytesRequest)
 	{
 		exitOp(SHTC3_Status_Error, __FILE__, __LINE__);
@@ -311,7 +311,7 @@ SHTC3_Status_TypeDef SHTC3::update()
 	case SHTC3_CMD_CSE_RHF_LPM:
 	case SHTC3_CMD_CSE_TF_NPM:
 	case SHTC3_CMD_CSE_TF_LPM:	   // Address+read will yield an ACK and then clock stretching will occur
-		numBytesRx = _wire->requestFrom(SHTC3_ADDR_7BIT, numBytesRequest);
+		numBytesRx = _wire->requestFrom((uint8_t)SHTC3_ADDR_7BIT, numBytesRequest);
 		break;
 
 	case SHTC3_CMD_CSD_RHF_NPM:


### PR DESCRIPTION
I was trying to use this lib with esp32, and got the following errors:

```
In file included from /home/bburdette/Arduino/libraries/SparkFun_SHTC3_Humidity_and_Temperature_Sensor_Library/src/SparkFun_SHTC3.h:11:0,
                 from /home/bburdette/Arduino/libraries/SparkFun_SHTC3_Humidity_and_Temperature_Sensor_Library/src/SparkFun_SHTC3.cpp:7:
/home/bburdette/.arduino15/packages/automato/hardware/esp32/0.0.1/libraries/Wire/src/Wire.h: In member function 'SHTC3_Status_TypeDef SHTC3::checkID()':
/home/bburdette/.arduino15/packages/automato/hardware/esp32/0.0.1/libraries/Wire/src/Wire.h:103:13: note: candidate 1: uint8_t TwoWire::requestFrom(int, int)
     uint8_t requestFrom(int address, int size);
             ^
/home/bburdette/.arduino15/packages/automato/hardware/esp32/0.0.1/libraries/Wire/src/Wire.h:101:13: note: candidate 2: uint8_t TwoWire::requestFrom(uint8_t, uint8_t)
     uint8_t requestFrom(uint8_t address, uint8_t size);
             ^
/home/bburdette/.arduino15/packages/automato/hardware/esp32/0.0.1/libraries/Wire/src/Wire.h:103:13: note: candidate 1: uint8_t TwoWire::requestFrom(int, int)
     uint8_t requestFrom(int address, int size);
             ^
/home/bburdette/.arduino15/packages/automato/hardware/esp32/0.0.1/libraries/Wire/src/Wire.h:99:13: note: candidate 2: uint8_t TwoWire::requestFrom(uint16_t, uint8_t)
     uint8_t requestFrom(uint16_t address, uint8_t size);
             ^
/home/bburdette/.arduino15/packages/automato/hardware/esp32/0.0.1/libraries/Wire/src/Wire.h: In member function 'SHTC3_Status_TypeDef SHTC3::update()':
/home/bburdette/.arduino15/packages/automato/hardware/esp32/0.0.1/libraries/Wire/src/Wire.h:103:13: note: candidate 1: uint8_t TwoWire::requestFrom(int, int)
     uint8_t requestFrom(int address, int size);
             ^
/home/bburdette/.arduino15/packages/automato/hardware/esp32/0.0.1/libraries/Wire/src/Wire.h:101:13: note: candidate 2: uint8_t TwoWire::requestFrom(uint8_t, uint8_t)
     uint8_t requestFrom(uint8_t address, uint8_t size);
             ^
/home/bburdette/.arduino15/packages/automato/hardware/esp32/0.0.1/libraries/Wire/src/Wire.h:103:13: note: candidate 1: uint8_t TwoWire::requestFrom(int, int)
     uint8_t requestFrom(int address, int size);
             ^
/home/bburdette/.arduino15/packages/automato/hardware/esp32/0.0.1/libraries/Wire/src/Wire.h:99:13: note: candidate 2: uint8_t TwoWire::requestFrom(uint16_t, uint8_t)
     uint8_t requestFrom(uint16_t address, uint8_t size);
             ^
Sketch uses 292998 bytes (22%) of program storage space. Maximum is 1310720 bytes.
Global variables use 14636 bytes (4%) of dynamic memory, leaving 313044 bytes for local variables. Maximum is 327680 bytes.
```

The problem is the compiler treats `SHTC3_ADDR_7BIT` as an int, but `numBytesRequest` is uint8_t.  So it wants a version of `requestFrom` that takes (int, uint8_t) - but there isn't one of those in esp32.  There isn't one in AVR either though I haven't tried compiling on that.  

At any rate, seems the problem would be solved with a (uin8_t) cast, which I added.  Works for me!
