### PR TITLE
Add RAK1901 product reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Products that use this Library
 * [SEN-18632](https://www.sparkfun.com/products/18632) - SparkFun MicroMod Environmental Function Board with SGP40, STC31, and SHTC3
 * [SEN-16467](https://www.sparkfun.com/products/16467) - SparkFun Humidity Sensor - SHTC3 (Qwiic)
 * [SPX-15074](https://www.sparkfun.com/products/15074) - SparkX Humidity Sensor Breakout SHTC3 (Qwiic)
+* [RAK1901](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK1901/Overview/) - RAKwireless WisBlock Temperature and Humidity Sensor
 
 
 Version History


### PR DESCRIPTION
Hello, not sure if Sparkfun is interested in referencing third-party hardware in documentation but I thought I'd link the RAK1901 module since the [official RAK library](https://github.com/RAKWireless/WisBlock/tree/master/examples/common/sensors/RAK1901_Temperature_Humidity_SHTC3) for their product explicitly mentions this library.

Feel free to close if not needed. Thanks for maintaining the codebase!